### PR TITLE
Add background sync for course POST requests

### DIFF
--- a/src/api/course/controllers/course.js
+++ b/src/api/course/controllers/course.js
@@ -125,7 +125,7 @@ module.exports = createCoreController('api::course.course', ({ strapi }) => ({
       }
     })
 
-    ctx.send({
+    return ctx.send({
       data: {
         message: 'User registered successfully'
       },

--- a/src/api/course/routes/custom-course.js
+++ b/src/api/course/routes/custom-course.js
@@ -1,7 +1,7 @@
 module.exports = {
   routes: [
     {
-      method: 'PUT',
+      method: 'POST',
       path: '/courses/:id/register',
       handler: 'course.register',
     },


### PR DESCRIPTION
The POST requests inside a course can be deferred that internet connectivity established again.